### PR TITLE
Fix for Sphinx >= 1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = ['Sphinx>=1.7', 'sphinxcontrib-domaintools>=0.1']
 
 setup(
     name='sphinxcontrib-cmakedomain',
-    version=domaintools.__version__,
+    version="0.2.1"
     url='http://bitbucket.org/klorenz/sphinxcontrib-cmakedomain',
     download_url='http://pypi.python.org/pypi/sphinxcontrib-cmakedomain',
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,6 @@ long_desc = '''
 This package contains a CMake domain.
 '''
 
-sys.path.insert(0, 'sphinxcontrib')
-import domaintools
-
 requires = ['Sphinx>=1.7', 'sphinxcontrib-domaintools>=0.1']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ This package contains a CMake domain.
 sys.path.insert(0, 'sphinxcontrib')
 import domaintools
 
-requires = ['Sphinx>=1.0', 'sphinxcontrib-domaintools>=0.1']
+requires = ['Sphinx>=1.7', 'sphinxcontrib-domaintools>=0.1']
 
 setup(
     name='sphinxcontrib-cmakedomain',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = ['Sphinx>=1.7', 'sphinxcontrib-domaintools>=0.1']
 
 setup(
     name='sphinxcontrib-cmakedomain',
-    version="0.2.1"
+    version="0.2.1",
     url='http://bitbucket.org/klorenz/sphinxcontrib-cmakedomain',
     download_url='http://pypi.python.org/pypi/sphinxcontrib-cmakedomain',
     license='BSD',

--- a/sphinxcontrib/cmakedomain.py
+++ b/sphinxcontrib/cmakedomain.py
@@ -20,7 +20,7 @@ from sphinx.locale import l_, _
 from sphinx.directives import ObjectDescription
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 cmake_param_desc_re = re.compile(
     r'([-_a-zA-Z0-9]+)\s+(.*)')


### PR DESCRIPTION
Directive was removed from sphinx.util.compat
We now use docutils.parsers.rst.Directive